### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,19 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./


### PR DESCRIPTION
## Summary
- add a minimal workflow to deploy the repository's root files to GitHub Pages when pushing to `master`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e563d80c8324b1f08e34b2a0797b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated deployment to GitHub Pages, enabling the site to be published automatically on each push to the master branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->