### PR TITLE
Fix blank page issue for subdirectory deployment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ function App() {
     <div className="container text-center mt-5">
       <h1 className="display-4">Welcome to Crypto Exchange</h1>
       <p className="lead">Trade your favorite cryptocurrencies with ease.</p>
+      <p className="text-success">The website is running!</p>
       <a href="#" className="btn btn-primary btn-lg mt-3">Get Started</a>
     </div>
   );

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,6 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  // Use a relative base path so that the app works when served from a subdirectory
+  base: './',
 });


### PR DESCRIPTION
## Summary
- fix base path in vite config to work from subdirectories
- show a message in the main page that the site is running

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ee562e34832496a0482be25a7325