### PR TITLE
Add simple client side auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # Simple GitHub Pages Site
 
-This repository hosts a minimal static page for GitHub Pages.
+This repository hosts a small static website for GitHub Pages.
 
-The site consists of a single `index.html` file that displays **Hello World**.
+The site now includes a basic client-side registration and login flow:
 
-A workflow in `.github/workflows/gh-pages.yml` automatically deploys this file whenever changes are pushed to the `master` branch.
+* `index.html` &ndash; landing page with links to register or log in.
+* `register.html` &ndash; create a new account (stored in `localStorage`).
+* `login.html` &ndash; authenticate using your stored credentials.
+* `dashboard.html` &ndash; simple user cabinet shown after successful login.
+
+Credentials are saved locally in the browser and are **not** secure; this setup is purely for demonstration.
+
+A workflow in `.github/workflows/gh-pages.yml` automatically deploys the site whenever changes are pushed to the `master` branch.

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background: #0d1117;
+            color: #e6edf3;
+            margin: 0;
+        }
+        header {
+            background: #161b22;
+            padding: 1rem 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            font-weight: 600;
+            color: #58a6ff;
+        }
+        main {
+            padding: 2rem;
+        }
+        button {
+            padding: 0.5rem 1rem;
+            background: #238636;
+            border: none;
+            border-radius: 4px;
+            color: #fff;
+            font-weight: 600;
+        }
+        button:hover { background: #2ea043; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="logo">User Cabinet</div>
+        <button onclick="doLogout()">Logout</button>
+    </header>
+    <main>
+        <h2 id="welcome"></h2>
+        <p>This is your dashboard. You can customize this area with your own content.</p>
+    </main>
+    <script src="script.js"></script>
+    <script>
+        function init() {
+            var user = getCurrentUser();
+            if (!user) {
+                window.location.href = 'login.html';
+                return;
+            }
+            document.getElementById('welcome').textContent = 'Welcome, ' + user + '!';
+        }
+        function doLogout() {
+            logout();
+            window.location.href = 'login.html';
+        }
+        init();
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -112,7 +112,8 @@
         <i class="fas fa-bars menu-btn" onclick="toggleMenu()"></i>
         <nav id="nav">
             <a href="#features">Features</a>
-            <a href="#signup">Sign Up</a>
+            <a href="register.html">Sign Up</a>
+            <a href="login.html">Login</a>
             <a href="#contact">Contact</a>
         </nav>
     </header>
@@ -120,7 +121,7 @@
     <section class="hero">
         <h1>Trade Crypto with Confidence</h1>
         <p>Join Coin Market and experience a secure, lightning-fast platform for all your cryptocurrency trading needs.</p>
-        <a href="#signup" class="btn">Get Started</a>
+        <a href="register.html" class="btn">Get Started</a>
     </section>
 
     <section class="features" id="features">
@@ -149,7 +150,7 @@
     <section class="hero" id="signup" style="background:#161b22;">
         <h2>Create Your Account</h2>
         <p>Ready to dive in? Start trading with Coin Market in minutes.</p>
-        <a href="#" class="btn">Join Now</a>
+        <a href="register.html" class="btn">Join Now</a>
     </section>
 
     <footer id="contact">

--- a/login.html
+++ b/login.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background: #0d1117;
+            color: #e6edf3;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            background: #161b22;
+            padding: 2rem;
+            border-radius: 8px;
+            width: 300px;
+        }
+        input {
+            width: 100%;
+            padding: 0.5rem;
+            margin-bottom: 1rem;
+            border: none;
+            border-radius: 4px;
+        }
+        button {
+            width: 100%;
+            padding: 0.5rem;
+            background: #238636;
+            border: none;
+            border-radius: 4px;
+            color: #fff;
+            font-weight: 600;
+        }
+        button:hover {
+            background: #2ea043;
+        }
+        .msg {
+            margin-bottom: 1rem;
+            color: #ff7b72;
+        }
+        a { color: #58a6ff; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>Login</h2>
+        <div class="msg" id="msg"></div>
+        <input type="text" id="username" placeholder="Username">
+        <input type="password" id="password" placeholder="Password">
+        <button onclick="login()">Login</button>
+        <p>Don't have an account? <a href="register.html">Register</a></p>
+    </div>
+    <script src="script.js"></script>
+    <script>
+        function login() {
+            var user = document.getElementById('username').value.trim();
+            var pass = document.getElementById('password').value;
+            var msg = document.getElementById('msg');
+            if(!user || !pass) {
+                msg.textContent = 'Please fill all fields';
+                return;
+            }
+            if (validateUser(user, pass)) {
+                setCurrentUser(user);
+                window.location.href = 'dashboard.html';
+            } else {
+                msg.textContent = 'Invalid credentials';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign Up</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background: #0d1117;
+            color: #e6edf3;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            background: #161b22;
+            padding: 2rem;
+            border-radius: 8px;
+            width: 300px;
+        }
+        input {
+            width: 100%;
+            padding: 0.5rem;
+            margin-bottom: 1rem;
+            border: none;
+            border-radius: 4px;
+        }
+        button {
+            width: 100%;
+            padding: 0.5rem;
+            background: #238636;
+            border: none;
+            border-radius: 4px;
+            color: #fff;
+            font-weight: 600;
+        }
+        button:hover {
+            background: #2ea043;
+        }
+        .msg {
+            margin-bottom: 1rem;
+            color: #ff7b72;
+        }
+        a { color: #58a6ff; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>Create Account</h2>
+        <div class="msg" id="msg"></div>
+        <input type="text" id="username" placeholder="Username">
+        <input type="password" id="password" placeholder="Password">
+        <button onclick="register()">Register</button>
+        <p>Already have an account? <a href="login.html">Login</a></p>
+    </div>
+    <script src="script.js"></script>
+    <script>
+        function register() {
+            var user = document.getElementById('username').value.trim();
+            var pass = document.getElementById('password').value;
+            var msg = document.getElementById('msg');
+            if(!user || !pass) {
+                msg.textContent = 'Please fill all fields';
+                return;
+            }
+            if (registerUser(user, pass)) {
+                msg.style.color = '#3fb950';
+                msg.textContent = 'Registration successful. Redirecting...';
+                setTimeout(function(){ window.location.href = 'login.html'; }, 1000);
+            } else {
+                msg.textContent = 'User already exists';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,34 @@
+function loadUsers() {
+  return JSON.parse(localStorage.getItem('users') || '[]');
+}
+
+function saveUsers(users) {
+  localStorage.setItem('users', JSON.stringify(users));
+}
+
+function registerUser(username, password) {
+  const users = loadUsers();
+  if (users.find(u => u.username === username)) {
+    return false; // user exists
+  }
+  users.push({ username, password });
+  saveUsers(users);
+  return true;
+}
+
+function validateUser(username, password) {
+  const users = loadUsers();
+  return users.find(u => u.username === username && u.password === password);
+}
+
+function setCurrentUser(username) {
+  localStorage.setItem('currentUser', username);
+}
+
+function getCurrentUser() {
+  return localStorage.getItem('currentUser');
+}
+
+function logout() {
+  localStorage.removeItem('currentUser');
+}


### PR DESCRIPTION
## Summary
- add basic client-side registration/login using localStorage
- create pages for registration, login and a dashboard
- link the new pages from the landing page
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68427bf224c88324a0dcfab87938af57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a multi-page static website with user registration, login, and dashboard functionality.
  - Added dedicated pages for registration, login, and a personalized dashboard.
  - Implemented client-side user management, including registration, authentication, and session handling using local storage.

- **Documentation**
  - Updated the README to describe the expanded site structure and new user flow, highlighting the demonstration nature and local credential storage.

- **Style**
  - Applied a consistent dark theme and modern font styling across all new and updated pages for an improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->